### PR TITLE
Update Chart.yaml

### DIFF
--- a/incubator/cert-manager/Chart.yaml
+++ b/incubator/cert-manager/Chart.yaml
@@ -1,3 +1,4 @@
+apiVersion: v1
 name: cert-manager
 version: 0.2.0
 appVersion: v0.4.0


### PR DESCRIPTION
Hey was running through the tutorial on local (Arch+i3wm). 

Came across this error: 

sugarkube kapps install stacks/web.yaml local-web workspaces/local-web/ --run-actions:

```
Error installing kapp. Aborting.

Error: Error processing kapp: Error planning kapp 'cert-manager': Failed to run command 'KUBECONFIG= helm lint --kube-context=minikube --namespace=cert-manager . -f=/home/patrick/devops/sample-project/workspaces/local-web/bootstrap/cert-manager/.sugarkube/github.com-sugarkube-kapps-cert-manager/incubator/cert-manager/values.yaml -f=/home/patrick/devops/sample-project/workspaces/local-web/bootstrap/cert-manager/.sugarkube/github.com-sugarkube-kapps-cert-manager/incubator/cert-manager/k8s/_generated_namespace.yaml' in directory '/home/patrick/devops/sample-project/workspaces/local-web/bootstrap/cert-manager/cert-manager'. It exited with a code of '1' but '0' was expected.
Stdout===> Linting .
[ERROR] Chart.yaml: apiVersion is required
[INFO] Chart.yaml: icon is recommended


Stderr=Error: 1 chart(s) linted, 1 chart(s) failed
: exit status 1
```